### PR TITLE
access the instance right way

### DIFF
--- a/helpers/utilities.php
+++ b/helpers/utilities.php
@@ -22,7 +22,7 @@ function is_feature_flagged( $feature ) {
 		return false;
 	}
 
-	return FeatureFlags::get_instance->feature_flagged( $feature );
+	return FeatureFlags::get_instance()->feature_flagged( $feature );
 }
 
 /**


### PR DESCRIPTION
It fixes fatal error during the plugin activation